### PR TITLE
removed example css and images

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>jqwidgets</artifactId>
-    <version>3.4.1-SNAPSHOT</version>
+    <version>3.4.0.1-SNAPSHOT</version>
     <name>jQWidgets</name>
     <description>WebJar for jQWidgets</description>
     <url>http://webjars.org</url>
@@ -103,7 +103,7 @@
                                 <unzip src="${project.build.directory}/${project.artifactId}.zip" dest="${project.build.directory}/zip" />
                                 <echo message="moving resources" />
                                 <move todir="${destDir}">
-                                    <fileset dir="${project.build.directory}/zip" includes="jqwidgets/ styles/ images/" />
+                                    <fileset dir="${project.build.directory}/zip/jqwidgets" />
                                 </move>
                             </target>
                         </configuration>


### PR DESCRIPTION
Hi James,

please find my suggested change below. I was wondering why the jar file was that big as I figured out, that all example images (like harry-potter-cover.jpg) and an examle css were also included. For jqwidgets, the jqwidgets sub folder of the zip archive is enough.

Best regards, Eric
